### PR TITLE
Fix typo 'acceptible'

### DIFF
--- a/kernel/linux/include/asm-ppc/pnp.h
+++ b/kernel/linux/include/asm-ppc/pnp.h
@@ -543,7 +543,7 @@ typedef union _PnP_TAG_PACKET {
     unsigned char Tag;                  /* small tag = 0x30 or 0x31           */
     unsigned char Priority;             /* Optional; if missing then x01; else*/
                                         /*  x00 = best possible               */
-                                        /*  x01 = acceptible                  */
+                                        /*  x01 = acceptable                  */
                                         /*  x02 = sub-optimal but functional  */
     } S6_Pack;
 


### PR DESCRIPTION
Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'acceptable', you typed 'acceptible'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

If you decide to close this pull request, pleace specify why before doing so.

With kind regards,
TheTypoMaster
